### PR TITLE
fix: delete partial selection

### DIFF
--- a/src/input.handler.ts
+++ b/src/input.handler.ts
@@ -62,10 +62,8 @@ export class InputHandler {
             event.preventDefault();
             let selectionRangeLength = Math.abs(this.inputService.inputSelection.selectionEnd - this.inputService.inputSelection.selectionStart);
 
-            if (selectionRangeLength == 0) {
-                this.inputService.removeNumber(keyCode);
-                this.onModelChange(this.inputService.value);
-            }
+            this.inputService.removeNumber(keyCode);
+            this.onModelChange(this.inputService.value);
 
             if (selectionRangeLength >= (this.inputService.rawValue.length - this.inputService.prefixLength())) {
                 this.clearValue();


### PR DESCRIPTION
1. Type "12345" in the input field, masked with ngx-currency.
2. Select "45" from the value, inside the input field.
3. Use either backspace or delete and try to delete the partial selection. 

Expected result:
45 is deleted and the current value is 123

Current result:
Nothing happens.