### PR TITLE
fix(applyMask): Apply mask was not considering precision

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -76,7 +76,11 @@ export class InputService {
         let decimalPart = onlyNumbers.slice(onlyNumbers.length - precision);
 
         if (precision > 0) {
-            newRawValue += decimal + decimalPart;
+            if (newRawValue == "0") {
+                newRawValue += decimal + "0".repeat(precision - 1) + decimalPart;
+            } else {
+                newRawValue += decimal + decimalPart;
+            }
         }
 
         let isZero = parseInt(integerPart) == 0 && (parseInt(decimalPart) == 0 || decimalPart == "");

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -76,7 +76,7 @@ export class InputService {
         let decimalPart = onlyNumbers.slice(onlyNumbers.length - precision);
 
         if (precision > 0) {
-            if (newRawValue == "0") {
+            if (newRawValue == "0" && decimalPart.length < precision) {
                 newRawValue += decimal + "0".repeat(precision - 1) + decimalPart;
             } else {
                 newRawValue += decimal + decimalPart;

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -1,5 +1,4 @@
 import { InputService } from './../src/input.service';
-import { fakeAsync } from "@angular/core/testing";
 import { expect } from "chai";
 import { stub } from 'sinon';
 import {CurrencyMaskConfig} from "../src/currency-mask.config";
@@ -66,6 +65,56 @@ describe('Testing InputService', () => {
 
       const result = inputService.applyMask(false, '234567');
       expect(result).to.equal('234567');
+    });
+  });
+  
+  describe('applyMask', ()=> {
+    it('should use precision 2 and consider decimal part when typing 1 with empty value', () => {        
+      options.precision = 2;
+
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0
+      }, options);
+
+      const result = inputService.applyMask(false, '1');
+      expect(result).to.be.equal('0,01');
+    });
+
+    it('should use precision 3 and consider decimal part when typing 1 with empty value', () => {
+      options.precision = 3;
+
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0
+      }, options);
+
+      const result = inputService.applyMask(false, '1');
+      expect(result).to.be.equal('0,001');
+    });
+
+    it('should use precision 2 when typing a key with previous value', () => {
+      options.precision = 2;
+
+      inputService = new InputService({
+        selectionStart: 6,
+        selectionEnd: 6
+      }, options);
+      
+      const result = inputService.applyMask(false, '12345');
+      expect(result).to.be.equal('123,45');
+    });
+
+    it('should use precision 3 when typing a key with previous value', () => {
+      options.precision = 3;
+
+      inputService = new InputService({
+          selectionStart: 6,
+          selectionEnd: 6
+        }, options);
+
+      const result = inputService.applyMask(false, '234567');
+      expect(result).to.be.equal('234,567');
     });
   });
 });


### PR DESCRIPTION
If I had configured precision to be 2 digits, for example, when the input was empty ("0.00" value) and selected and I typed the char "1", it was masking the value to "0.1" instead of "0.01", and the same logic to 3 or more digits of precision. Added verification to validate if the rawValue is zero and then, repeat the "0" char according to configured precision.

Examples:

Precision=2
Before:
- Input value was 0.00;
- User selects input text;
- User types "1"
- Input value becomes "0.1"

After:
- Input value was 0.00;
- User selects input text;
- User types "1"
- Input value becomes "0.01"

Precision=3
Before:
- Input value was 0.00;
- User selects input text;
- User types "1"
- Input value becomes "0.1"

After:
- Input value was 0.00;
- User selects input text;
- User types "1"
- Input value becomes "0.001"
