### PR TITLE
feat(applyMask): Adds support for min and max

### DIFF
--- a/demo/demo.component.ts
+++ b/demo/demo.component.ts
@@ -32,7 +32,8 @@ export class DemoComponent {
     thousands: '.',
     decimal: ',',
     allowNegative: false,
-    nullable: true
+    nullable: true,
+    max: 250_000_000,
   };
 
   constructor(private formBuilder: FormBuilder) {

--- a/src/currency-mask.config.ts
+++ b/src/currency-mask.config.ts
@@ -10,6 +10,8 @@ export interface CurrencyMaskConfig {
   suffix: string;
   thousands: string;
   nullable: boolean;
+  min?: number;
+  max?: number;
 }
 
 export let CURRENCY_MASK_CONFIG = new InjectionToken<CurrencyMaskConfig>("currency.mask.config");

--- a/src/input.handler.ts
+++ b/src/input.handler.ts
@@ -103,7 +103,7 @@ export class InputHandler {
                     let selectionRangeLength = Math.abs(this.inputService.inputSelection.selectionEnd - this.inputService.inputSelection.selectionStart);
 
                     if (selectionRangeLength == this.inputService.rawValue.length) {
-                        this.setValue(0);
+                        this.setValue(null);
                     }
 
                     this.inputService.addNumber(keyCode);


### PR DESCRIPTION
This change adds min and max options to the config. I made them optional in the CurrencyMaskConfig interface to avoid making a breaking change. I added a max value to the demo.

The changes support a fully positive range (eg. 10 to 100) and a fully negative range (eg. -10 to -100). I verified that typing and pasting work correctly in both cases. It also gracefully handles an invalid range where min > max (uses max for both).

I added test cases and manually tested with multiple combinations.

See Issue #68 