### PR TITLE
fix: Ignore special characters when validating maxLength

### DIFF
--- a/src/input.manager.ts
+++ b/src/input.manager.ts
@@ -26,7 +26,8 @@ export class InputManager {
     }
 
     get canInputMoreNumbers(): boolean {
-        let haventReachedMaxLength = !(this.rawValue.length >= this.htmlInputElement.maxLength && this.htmlInputElement.maxLength >= 0);
+        let onlyNumbers = this.rawValue.replace(/[^0-9\u0660-\u0669\u06F0-\u06F9]/g, "");
+        let haventReachedMaxLength = !(onlyNumbers.length >= this.htmlInputElement.maxLength && this.htmlInputElement.maxLength >= 0);
         let selectionStart = this.inputSelection.selectionStart;
         let selectionEnd = this.inputSelection.selectionEnd;
         let haveNumberSelected = !!(selectionStart != selectionEnd &&

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -89,6 +89,29 @@ describe('Testing InputService', () => {
     });
   });
 
+  describe('canInputMoreNumbers', () => {
+    it('should return false when length of numbersOnlyInput >= maxLength', () => {
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0,
+        maxLength: 6,
+        value: 0
+      }, options);
+      inputService.inputManager.rawValue = '$1,234.56';
+      expect(inputService.canInputMoreNumbers).to.be.false;
+    });
+    it('should return true when length of numbersOnlyInput < maxLength', () => {
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0,
+        maxLength: 6,
+        value: 0
+      }, options);
+      inputService.inputManager.rawValue = '$123.45';
+      expect(inputService.canInputMoreNumbers).to.be.true;
+    });
+  });
+
   describe('applyMask', ()=> {
     it('should use precision 2 and consider decimal part when typing 1 with empty value', () => {        
       options.precision = 2;


### PR DESCRIPTION
https://github.com/nbfontana/ngx-currency/issues/43

Issue: The maxLength field on an input tag is not working correctly as we are comparing the raw value (which includes special characters) instead of only numbers.
Fix: Update the "haventReachedMaxLength" check to use 'onlyNumbers' instead of 'rawValue'.