### PR TITLE
feat(addNumber): Typing decimal or thousands advances cursor

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -45,8 +45,19 @@ export class InputService {
         } else {
             let selectionStart = this.inputSelection.selectionStart;
             let selectionEnd = this.inputSelection.selectionEnd;
-            this.rawValue = this.rawValue.substring(0, selectionStart) + keyChar + this.rawValue.substring(selectionEnd, this.rawValue.length);
-            this.updateFieldValue(selectionStart + 1);
+            const rawValueStart = this.rawValue.substring(0, selectionStart);
+            const rawValueEnd = this.rawValue.substring(selectionEnd, this.rawValue.length);
+            this.rawValue = rawValueStart + keyChar + rawValueEnd;
+            let nextSelectionStart = selectionStart + 1;
+
+            // If the cursor is just before the decimal or thousands separator and the user types the
+            // decimal or thousands separator, move the cursor past it.
+            if ((keyChar === this.options.decimal || keyChar === this.options.thousands) && 
+                keyChar === rawValueEnd.substring(0, 1)) {
+                nextSelectionStart++;
+            }
+
+            this.updateFieldValue(nextSelectionStart);
         }
     }
 

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -87,6 +87,57 @@ describe('Testing InputService', () => {
       inputService.addNumber(50); // '2'
       expect(inputService.value).to.be.equal(10);
     });
+
+    it('should move past decimal when decimal typed', () => {
+      const htmlInputElement = new MockHtmlInputElement(2, 2);
+      options.precision = 2;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '12,34';
+
+      // Typing , moves past the decimal separator.
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(12.34);
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
+
+      // Typing it again should not move selection because we're already passed the separator.
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(12.34);
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
+    });
+
+    it('should move past decimal when decimal typed with selection range', () => {
+      const htmlInputElement = new MockHtmlInputElement(1, 3);
+      options.precision = 2;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '123,45';
+
+      // "23" are selected. Typing , deletes the selection AND moves past the decimal separator.
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(1.45);
+      expect(htmlInputElement.selectionStart).to.be.equal(2);
+      expect(htmlInputElement.selectionEnd).to.be.equal(2);
+    });
+
+    it('should move past thousands separator when thousands separator typed', () => {
+      const htmlInputElement = new MockHtmlInputElement(1, 1);
+      options.precision = 2;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '1.234,56';
+
+      // Typing . moves past the thousands separator.
+      inputService.addNumber(46); // '.'
+      expect(inputService.value).to.be.equal(1234.56);
+      expect(htmlInputElement.selectionStart).to.be.equal(2);
+      expect(htmlInputElement.selectionEnd).to.be.equal(2);
+
+      // Typing it again should not move selection because we're already passed the separator.
+      inputService.addNumber(46); // '.'
+      expect(inputService.value).to.be.equal(1234.56);
+      expect(htmlInputElement.selectionStart).to.be.equal(2);
+      expect(htmlInputElement.selectionEnd).to.be.equal(2);
+    });
   });
 
   describe('applyMask', ()=> {
@@ -211,3 +262,22 @@ describe('Testing InputService', () => {
     });
   });
 });
+
+class MockHtmlInputElement {
+
+  public focused: boolean;
+
+  constructor(
+    public selectionStart: number,
+    public selectionEnd: number,
+  ) {}
+
+  public focus(): void {
+    this.focused = true;    
+  }
+
+  public setSelectionRange(selectionStart: number, selectionEnd: number): void {
+    this.selectionStart = selectionStart;
+    this.selectionEnd = selectionEnd;
+  }
+}


### PR DESCRIPTION
If the cursor or selection is just before the decimal or thousands, then
typing the decimal or thousands advances the cursor past it.  For
example, if the value is "$1,234.56" and the cursor just just after the
4, then typing "." will advance the cursor past the decimal.

See issue #79 