### PR TITLE
feat(addNumber): Adds support for natural input mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,29 @@ Available options:
  * `suffix` - Money suffix (default: `''`)
  * `thousands` - Separator of thousands (default: `','`)
  * `nullable` - when true, the value of the clean field will be `null`, when false the value will be `0`
+ * `min` - The minimum value (default: `undefined`)
+ * `max` - The maximum value (default: `undefined`)
+ * `inputMode` - Determines how to handle numbers as the user types them (default: `FINANCIAL`)
+
+Input Modes:
+
+ * `FINANCIAL` - Numbers start at the highest precision decimal. Typing a number shifts numbers left.
+                 The decimal character is ignored. Most cash registers work this way. For example:
+   * Typing `'12'` results in `'0.12'`
+   * Typing `'1234'` results in `'12.34'`
+   * Typing `'1.234'` results in `'12.34'`
+ * `NATURAL` - Numbers start to the left of the decimal. Typing a number to the left of the decimal shifts
+               numbers left; typing to the right of the decimal replaces the next number. Most text inputs
+               and spreadsheets work this way. For example:
+   * Typing `'1234'` results in `'1234'`
+   * Typing `'1.234'` results in `'1.23'`
+   * Typing `'12.34'` results in `'12.34'`
+   * Typing `'123.4'` results in `'123.40'`
 
 You can also set options globally...
 
 ```ts
-import { NgxCurrencyModule } from "ngx-currency";
+import { CurrencyMaskInputMode, NgxCurrencyModule } from "ngx-currency";
 
 export const customCurrencyMaskConfig = {
     align: "right",
@@ -89,7 +107,10 @@ export const customCurrencyMaskConfig = {
     prefix: "R$ ",
     suffix: "",
     thousands: ".",
-    nullable: true
+    nullable: true,
+    min: null,
+    max: null,
+    inputMode: CurrencyMaskInputMode.FINANCIAL
 };
 
 @NgModule({

--- a/demo/demo.component.ts
+++ b/demo/demo.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { CurrencyMaskInputMode } from '../src/currency-mask.config';
 
 @Component({
   selector: 'demo-app',
@@ -9,8 +10,8 @@ import { FormBuilder, FormGroup } from '@angular/forms';
         <div class="col-md-3 col-sm-5 form-group">
           <label>Example</label>
           <input
+            #valueInput
             class="form-control"
-            maxlength="20"
             currencyMask
             formControlName="value"
             [placeholder]="'R$ 0,00'"
@@ -18,14 +19,40 @@ import { FormBuilder, FormGroup } from '@angular/forms';
           />
         </div>
       </div>
+      <div class="row">
+        <div class="col-md-3 col-sm-5 form-group">
+          <label>Input Mode</label>
+          <div>
+            <label class="radio-inline">
+              <input
+                type="radio"
+                name="inputMode"
+                formControlName="inputMode"
+                [value]="0"
+              />Financial</label>
+            <label class="radio-inline">
+              <input
+                type="radio"
+                name="inputMode"
+                formControlName="inputMode"
+                [value]="1"
+              />Natural</label>
+            </div>
+          </div>
+      </div>
+
 
       <div class="row col-md-4 col-sm-6 form-group">
-        <pre style="width: 100%">{{ form.value | json }}</pre>
+        <label>Value</label>
+        <pre style="width: 100%">{{ form.get('value').value | json }}</pre>
       </div>
     </form>
   `
 })
 export class DemoComponent {
+
+  @ViewChild('valueInput', { static: true }) valueInput: ElementRef;
+
   public form: FormGroup;
   public ngxCurrencyOptions = {
     prefix: 'R$ ',
@@ -34,15 +61,27 @@ export class DemoComponent {
     allowNegative: false,
     nullable: true,
     max: 250_000_000,
+    inputMode: CurrencyMaskInputMode.FINANCIAL,
   };
 
   constructor(private formBuilder: FormBuilder) {
-    this.buildForm();
   }
 
-  private buildForm() {
+  ngOnInit() {
     this.form = this.formBuilder.group({
-      value: [null]
+      value: null,
+      inputMode: this.ngxCurrencyOptions.inputMode,
     });
+
+    this.form.get('inputMode').valueChanges.subscribe(val => {
+      this.ngxCurrencyOptions.inputMode = val;
+
+      // Clear and focus the value input when the input mode is changed.container
+      this.form.get('value').setValue(null);
+      this.valueInput.nativeElement.focus();
+    });
+
+    // Focus on the value input when the demo starts.
+    this.valueInput.nativeElement.focus();
   }
 }

--- a/src/currency-mask.config.ts
+++ b/src/currency-mask.config.ts
@@ -12,6 +12,12 @@ export interface CurrencyMaskConfig {
   nullable: boolean;
   min?: number;
   max?: number;
+  inputMode? : CurrencyMaskInputMode;
+}
+
+export enum CurrencyMaskInputMode {
+  FINANCIAL,
+  NATURAL,
 }
 
 export let CURRENCY_MASK_CONFIG = new InjectionToken<CurrencyMaskConfig>("currency.mask.config");

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -45,8 +45,19 @@ export class InputService {
         } else {
             let selectionStart = this.inputSelection.selectionStart;
             let selectionEnd = this.inputSelection.selectionEnd;
-            this.rawValue = this.rawValue.substring(0, selectionStart) + keyChar + this.rawValue.substring(selectionEnd, this.rawValue.length);
-            this.updateFieldValue(selectionStart + 1);
+            const rawValueStart = this.rawValue.substring(0, selectionStart);
+            const rawValueEnd = this.rawValue.substring(selectionEnd, this.rawValue.length);
+            this.rawValue = rawValueStart + keyChar + rawValueEnd;
+            let nextSelectionStart = selectionStart + 1;
+
+            // If the cursor is just before the decimal or thousands separator and the user types the
+            // decimal or thousands separator, move the cursor past it.
+            if ((keyChar === this.options.decimal || keyChar === this.options.thousands) && 
+                keyChar === rawValueEnd.substring(0, 1)) {
+                nextSelectionStart++;
+            }
+
+            this.updateFieldValue(nextSelectionStart);
         }
     }
 

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -1,8 +1,11 @@
-import {InputManager} from "./input.manager";
-import {CurrencyMaskConfig} from "./currency-mask.config";
-
+import { CurrencyMaskConfig, CurrencyMaskInputMode } from "./currency-mask.config";
+import { InputManager } from "./input.manager";
 
 export class InputService {
+
+    private static readonly SINGLE_DIGIT_REGEX = /^[0-9\u0660-\u0669\u06F0-\u06F9]$/;
+    private static readonly ONLY_NUMBERS_REGEX = /[^0-9\u0660-\u0669\u06F0-\u06F9]/g;
+
     PER_AR_NUMBER: Map<string, string> = new Map<string, string>();
 
     initialize() {
@@ -37,37 +40,61 @@ export class InputService {
     }
 
     addNumber(keyCode: number): void {
+        const {decimal, precision, inputMode} = this.options;
         let keyChar = String.fromCharCode(keyCode);
+        const isDecimalChar = keyChar === this.options.decimal;
 
         if (!this.rawValue) {
             this.rawValue = this.applyMask(false, keyChar);
-            this.updateFieldValue();
+            let selectionStart:number = undefined;
+            if (inputMode === CurrencyMaskInputMode.NATURAL && precision > 0) {
+                selectionStart = this.rawValue.indexOf(decimal);
+                if (isDecimalChar) {
+                    selectionStart++;
+                }
+            }
+            this.updateFieldValue(selectionStart);
         } else {
             let selectionStart = this.inputSelection.selectionStart;
             let selectionEnd = this.inputSelection.selectionEnd;
             const rawValueStart = this.rawValue.substring(0, selectionStart);
-            const rawValueEnd = this.rawValue.substring(selectionEnd, this.rawValue.length);
-            this.rawValue = rawValueStart + keyChar + rawValueEnd;
-            let nextSelectionStart = selectionStart + 1;
+            let rawValueEnd = this.rawValue.substring(selectionEnd, this.rawValue.length);
 
-            // If the cursor is just before the decimal or thousands separator and the user types the
-            // decimal or thousands separator, move the cursor past it.
-            if ((keyChar === this.options.decimal || keyChar === this.options.thousands) && 
-                keyChar === rawValueEnd.substring(0, 1)) {
-                nextSelectionStart++;
+            // In natural mode, replace decimals instead of shifting them.
+            const inDecimalPortion = rawValueStart.indexOf(decimal) !== -1;
+            if (inputMode === CurrencyMaskInputMode.NATURAL && inDecimalPortion && selectionStart === selectionEnd) {
+              rawValueEnd = rawValueEnd.substring(1);
             }
 
+            const newValue = rawValueStart + keyChar + rawValueEnd;
+            let nextSelectionStart = selectionStart + 1;
+            const isDecimalOrThousands = isDecimalChar || keyChar === this.options.thousands;
+            if (isDecimalOrThousands && keyChar === rawValueEnd[0]) {
+                // If the cursor is just before the decimal or thousands separator and the user types the
+                // decimal or thousands separator, move the cursor past it.
+                nextSelectionStart++;
+            } else if (!InputService.SINGLE_DIGIT_REGEX.test(keyChar)) {
+                // Ignore other non-numbers.
+                return;
+            }
+
+            this.rawValue = newValue;
             this.updateFieldValue(nextSelectionStart);
         }
     }
 
     applyMask(isNumber: boolean, rawValue: string): string {
-        let {allowNegative, decimal, precision, prefix, suffix, thousands, nullable, min, max} = this.options;
+        let {allowNegative, decimal, precision, prefix, suffix, thousands, min, max, inputMode} = this.options;
         rawValue = isNumber ? new Number(rawValue).toFixed(precision) : rawValue;
-        let onlyNumbers = rawValue.replace(/[^0-9\u0660-\u0669\u06F0-\u06F9]/g, "");
+        let onlyNumbers = rawValue.replace(InputService.ONLY_NUMBERS_REGEX, "");
 
-        if (!onlyNumbers) {
+        if (!onlyNumbers && rawValue !== decimal) {
             return "";
+        }
+
+        if (inputMode === CurrencyMaskInputMode.NATURAL && !isNumber) {
+            rawValue = this.padOrTrimPrecision(rawValue);
+            onlyNumbers = rawValue.replace(InputService.ONLY_NUMBERS_REGEX, "");
         }
 
         let integerPart = onlyNumbers.slice(0, onlyNumbers.length - precision)
@@ -114,6 +141,28 @@ export class InputService {
         let isZero = newValue == 0;
         let operator = (isNegative && allowNegative && !isZero) ? "-" : "";
         return operator + prefix + newRawValue + suffix;
+    }
+
+    padOrTrimPrecision(rawValue: string): string {
+        let {decimal, precision} = this.options;
+
+        let decimalIndex = rawValue.lastIndexOf(decimal);
+        if (decimalIndex === -1) {
+            decimalIndex = rawValue.length;
+            rawValue += decimal;
+        }
+
+        let decimalPortion = rawValue.substring(decimalIndex).replace(InputService.ONLY_NUMBERS_REGEX, "");
+        const actualPrecision = decimalPortion.length;
+        if (actualPrecision < precision) {
+            for (let i = actualPrecision; i < precision; i++) {
+                decimalPortion += '0';
+            }    
+        } else if (actualPrecision > precision) {
+            decimalPortion = decimalPortion.substring(0, decimalPortion.length + precision - actualPrecision);
+        }
+
+        return rawValue.substring(0, decimalIndex) + decimal + decimalPortion;
     }
 
     clearMask(rawValue: string): number {
@@ -186,6 +235,7 @@ export class InputService {
     updateFieldValue(selectionStart?: number): void {
         let newRawValue = this.applyMask(false, this.rawValue || "");
         selectionStart = selectionStart == undefined ? this.rawValue.length : selectionStart;
+        selectionStart = Math.max(this.options.prefix.length, Math.min(selectionStart, this.rawValue.length - this.options.suffix.length));
         this.inputManager.updateValueAndCursor(newRawValue, this.rawValue.length, selectionStart);
     }
 

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -1,7 +1,7 @@
 import { InputService } from './../src/input.service';
 import { expect } from "chai";
 import { stub } from 'sinon';
-import {CurrencyMaskConfig} from "../src/currency-mask.config";
+import {CurrencyMaskConfig, CurrencyMaskInputMode} from "../src/currency-mask.config";
 
 describe('Testing InputService', () => {
   
@@ -138,6 +138,67 @@ describe('Testing InputService', () => {
       expect(htmlInputElement.selectionStart).to.be.equal(2);
       expect(htmlInputElement.selectionEnd).to.be.equal(2);
     });
+
+    it('should start before decimal char from empty string in natural mode', () => {
+      const htmlInputElement = new MockHtmlInputElement(0, 0);
+      options.precision = 2;
+      options.prefix = '$$$',
+      options.suffix =  '!!!',
+      options.inputMode = CurrencyMaskInputMode.NATURAL;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '';
+
+      inputService.addNumber(50); // '2'
+      expect(inputService.value).to.be.equal(2);
+      expect(inputService.rawValue).to.be.equal('$$$2,00!!!');
+      expect(htmlInputElement.selectionStart).to.be.equal(4);
+      expect(htmlInputElement.selectionEnd).to.be.equal(4);
+    });
+
+    it('should start after decimal char from empty string in natural mode', () => {
+      const htmlInputElement = new MockHtmlInputElement(0, 0);
+      options.precision = 2;
+      options.prefix = '$$$',
+      options.suffix =  '!!!',
+      options.inputMode = CurrencyMaskInputMode.NATURAL;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '';
+
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(0);
+      expect(inputService.rawValue).to.be.equal('$$$0,00!!!');
+      expect(htmlInputElement.selectionStart).to.be.equal(5);
+      expect(htmlInputElement.selectionEnd).to.be.equal(5);
+    });
+
+    it('should replace decimals in natural mode', () => {
+      const htmlInputElement = new MockHtmlInputElement(6, 6);
+      options.precision = 2;
+      options.prefix = '$$$',
+      options.suffix =  '!!!',
+      options.inputMode = CurrencyMaskInputMode.NATURAL;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '$$$12,34!!!';
+
+      inputService.addNumber(53); // '5'
+      expect(inputService.value).to.be.equal(12.54);
+      expect(inputService.rawValue).to.be.equal('$$$12,54!!!');
+      expect(htmlInputElement.selectionStart).to.be.equal(7);
+      expect(htmlInputElement.selectionEnd).to.be.equal(7);
+
+      inputService.addNumber(54); // '6'
+      expect(inputService.value).to.be.equal(12.56);
+      expect(inputService.rawValue).to.be.equal('$$$12,56!!!');
+      expect(htmlInputElement.selectionStart).to.be.equal(8);
+      expect(htmlInputElement.selectionEnd).to.be.equal(8);
+
+      // Ignore characters that would increase past max precision.
+      inputService.addNumber(55); // '7'
+      expect(inputService.value).to.be.equal(12.56);
+      expect(inputService.rawValue).to.be.equal('$$$12,56!!!');
+      expect(htmlInputElement.selectionStart).to.be.equal(8);
+      expect(htmlInputElement.selectionEnd).to.be.equal(8);
+    });
   });
 
   describe('applyMask', ()=> {
@@ -259,6 +320,72 @@ describe('Testing InputService', () => {
 
       expect(inputService.applyMask(false, '-1')).to.be.equal('-1');
       expect(inputService.applyMask(false, '10')).to.be.equal('10');
+    });
+
+    it('should pad or trim in natural mode', () => {
+      options.precision = 2;
+      options.min = null;
+      options.max = null;
+      options.inputMode = CurrencyMaskInputMode.NATURAL;
+      inputService = new InputService({
+          selectionStart: 0,
+          selectionEnd: 0
+        }, options);
+
+      expect(inputService.applyMask(false, '1')).to.be.equal('1,00');
+      expect(inputService.applyMask(false, '12,34')).to.be.equal('12,34');
+      expect(inputService.applyMask(false, '12,345')).to.be.equal('12,34');
+    });
+
+    it('should return formatted string when decimal char typed', () => {
+      options.precision = 2;
+      options.min = null;
+      options.max = null;
+      options.inputMode = CurrencyMaskInputMode.NATURAL;
+      inputService = new InputService({
+          selectionStart: 0,
+          selectionEnd: 0
+        }, options);
+
+      expect(inputService.applyMask(false, ',')).to.be.equal('0,00');
+    });
+  });
+
+  describe('padOrTrimPrecision', () => {
+    it('should pad if insufficient precision', () => {
+      options.precision = 3;
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0,
+      }, options);
+
+      expect(inputService.padOrTrimPrecision('1.234')).to.be.equal('1.234,000');
+      expect(inputService.padOrTrimPrecision('1.234,5')).to.be.equal('1.234,500');
+      expect(inputService.padOrTrimPrecision('1.234,56')).to.be.equal('1.234,560');
+      expect(inputService.padOrTrimPrecision('1.234,567')).to.be.equal('1.234,567');
+    });
+
+    it('should trim excess decimals', () => {
+      options.precision = 2;
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0,
+      }, options);
+
+      expect(inputService.padOrTrimPrecision('1.234,56')).to.be.equal('1.234,56');
+      expect(inputService.padOrTrimPrecision('1.234,567')).to.be.equal('1.234,56');
+      expect(inputService.padOrTrimPrecision('1.234,5678')).to.be.equal('1.234,56');
+    });
+
+    it('should trim all decimals if 0 precision', () => {
+      options.precision = 0;
+      inputService = new InputService({
+        selectionStart: 0,
+        selectionEnd: 0,
+      }, options);
+
+      expect(inputService.padOrTrimPrecision('1.234,56')).to.be.equal('1.234,');
+      expect(inputService.padOrTrimPrecision('1.234')).to.be.equal('1.234,');
     });
   });
 });

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -87,6 +87,57 @@ describe('Testing InputService', () => {
       inputService.addNumber(50); // '2'
       expect(inputService.value).to.be.equal(10);
     });
+
+    it('should move past decimal when decimal typed', () => {
+      const htmlInputElement = new MockHtmlInputElement(2, 2);
+      options.precision = 2;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '12,34';
+
+      // Typing , moves past the decimal separator.
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(12.34);
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
+
+      // Typing it again should not move selection because we're already passed the separator.
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(12.34);
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
+    });
+
+    it('should move past decimal when decimal typed with selection range', () => {
+      const htmlInputElement = new MockHtmlInputElement(1, 3);
+      options.precision = 2;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '123,45';
+
+      // "23" are selected. Typing , deletes the selection AND moves past the decimal separator.
+      inputService.addNumber(44); // ','
+      expect(inputService.value).to.be.equal(1.45);
+      expect(htmlInputElement.selectionStart).to.be.equal(2);
+      expect(htmlInputElement.selectionEnd).to.be.equal(2);
+    });
+
+    it('should move past thousands separator when thousands separator typed', () => {
+      const htmlInputElement = new MockHtmlInputElement(1, 1);
+      options.precision = 2;
+      inputService = new InputService(htmlInputElement, options);
+      inputService.inputManager.rawValue = '1.234,56';
+
+      // Typing . moves past the thousands separator.
+      inputService.addNumber(46); // '.'
+      expect(inputService.value).to.be.equal(1234.56);
+      expect(htmlInputElement.selectionStart).to.be.equal(2);
+      expect(htmlInputElement.selectionEnd).to.be.equal(2);
+
+      // Typing it again should not move selection because we're already passed the separator.
+      inputService.addNumber(46); // '.'
+      expect(inputService.value).to.be.equal(1234.56);
+      expect(htmlInputElement.selectionStart).to.be.equal(2);
+      expect(htmlInputElement.selectionEnd).to.be.equal(2);
+    });
   });
 
   describe('applyMask', ()=> {
@@ -211,3 +262,22 @@ describe('Testing InputService', () => {
     });
   });
 });
+
+class MockHtmlInputElement {
+
+  public focused: boolean;
+
+  constructor(
+    public selectionStart: number,
+    public selectionEnd: number,
+  ) {}
+
+  public focus(): void {
+    this.focused = true;    
+  }
+
+  public setSelectionRange(selectionStart: number, selectionEnd: number): void {
+    this.selectionStart = selectionStart;
+    this.selectionEnd = selectionEnd;
+  }
+}


### PR DESCRIPTION
Adds support for input modes. The default input mode is FINANCIAL, which works the same as it does today. The new input mode is NATURAL, which behaves more like a text editor/spreadsheet. Numbers start to the left of the decimal (aka the "dollar" amount). Typing a number to the right of the decimal replaces the next number. For example, typing "123.4" results in "123.40" instead of "12.34".

This PR builds on PR #78.

cc: @nbfontana 