### PR TITLE
fix: readOnly issue, special characters issue, drop event for partial selections

### DIFF
--- a/src/currency-mask.directive.ts
+++ b/src/currency-mask.directive.ts
@@ -111,6 +111,13 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
     }
   }
 
+  @HostListener("drop", ["$event"])
+  handleDrop(event: any) {
+    if (!this.isChromeAndroid()) {
+      event.preventDefault();
+    }
+  }
+
   isChromeAndroid(): boolean {
     return /chrome/i.test(navigator.userAgent) && /android/i.test(navigator.userAgent);
   }

--- a/src/currency-mask.directive.ts
+++ b/src/currency-mask.directive.ts
@@ -79,40 +79,44 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
   @HostListener("cut", ["$event"])
   handleCut(event: any) {
     if (!this.isChromeAndroid()) {
-      this.inputHandler.handleCut(event);
+      !this.isReadOnly() && this.inputHandler.handleCut(event);
     }
   }
 
   @HostListener("input", ["$event"])
   handleInput(event: any) {
     if (this.isChromeAndroid()) {
-      this.inputHandler.handleInput(event);
+      !this.isReadOnly() && this.inputHandler.handleInput(event);
     }
   }
 
   @HostListener("keydown", ["$event"])
   handleKeydown(event: any) {
     if (!this.isChromeAndroid()) {
-      this.inputHandler.handleKeydown(event);
+      !this.isReadOnly() && this.inputHandler.handleKeydown(event);
     }
   }
 
   @HostListener("keypress", ["$event"])
   handleKeypress(event: any) {
     if (!this.isChromeAndroid()) {
-      this.inputHandler.handleKeypress(event);
+      !this.isReadOnly() && this.inputHandler.handleKeypress(event);
     }
   }
 
   @HostListener("paste", ["$event"])
   handlePaste(event: any) {
     if (!this.isChromeAndroid()) {
-      this.inputHandler.handlePaste(event);
+      !this.isReadOnly() && this.inputHandler.handlePaste(event);
     }
   }
 
   isChromeAndroid(): boolean {
     return /chrome/i.test(navigator.userAgent) && /android/i.test(navigator.userAgent);
+  }
+
+  isReadOnly(): boolean {
+    return this.elementRef.nativeElement.hasAttribute('readonly')
   }
 
   registerOnChange(callbackFunction: Function): void {

--- a/src/input.handler.ts
+++ b/src/input.handler.ts
@@ -48,6 +48,7 @@ export class InputHandler {
                     }
 
                     this.inputService.addNumber(keyCode);
+                    break;
             }
         }
 
@@ -57,7 +58,6 @@ export class InputHandler {
 
     handleKeydown(event: any): void {
         let keyCode = event.which || event.charCode || event.keyCode;
-
         if (keyCode == 8 || keyCode == 46 || keyCode == 63272) {
             event.preventDefault();
             let selectionRangeLength = Math.abs(this.inputService.inputSelection.selectionEnd - this.inputService.inputSelection.selectionStart);
@@ -80,7 +80,7 @@ export class InputHandler {
 
     handleKeypress(event: any): void {
         let keyCode = event.which || event.charCode || event.keyCode;
-
+        event.preventDefault();
         if (keyCode === 97 && event.ctrlKey) {
             return;
         }
@@ -89,8 +89,6 @@ export class InputHandler {
             case undefined:
             case 9:
             case 13:
-            case 37:
-            case 39:
                 return;
             case 43:
                 this.inputService.changeToPositive();
@@ -108,9 +106,9 @@ export class InputHandler {
 
                     this.inputService.addNumber(keyCode);
                 }
+                break;
         }
 
-        event.preventDefault();
         this.onModelChange(this.inputService.value);
     }
 


### PR DESCRIPTION
@nbfontana,

So I managed to fix the following issues: 
1. #61, #55 (both are actually the same issue).
    Now you can't edit whenever there is a readonly attribute on input box. Simply checked for the attribute and then fire the event handler accordingly.
2. #50 
    Now you wont be able to enter the special characters like % and ' (single quotes).
3. #82 
    Simply added an event handler for the drop event and preventDefault() it.

Kindly Review the code and let me know if this is good.