### PR TITLE
fix: improve deletion

### DIFF
--- a/src/input.handler.ts
+++ b/src/input.handler.ts
@@ -60,15 +60,13 @@ export class InputHandler {
         let keyCode = event.which || event.charCode || event.keyCode;
         if (keyCode == 8 || keyCode == 46 || keyCode == 63272) {
             event.preventDefault();
-            let selectionRangeLength = Math.abs(this.inputService.inputSelection.selectionEnd - this.inputService.inputSelection.selectionStart);
 
-            if (selectionRangeLength == 0) {
+            if (this.inputService.inputSelection.selectionStart <= this.inputService.prefixLength() &&
+                this.inputService.inputSelection.selectionEnd >= this.inputService.rawValue.length - this.inputService.suffixLength()) {
+                this.clearValue();
+            } else {
                 this.inputService.removeNumber(keyCode);
                 this.onModelChange(this.inputService.value);
-            }
-
-            if (selectionRangeLength >= (this.inputService.rawValue.length - this.inputService.prefixLength())) {
-                this.clearValue();
             }
         }
     }

--- a/test/input-handler.spec.ts
+++ b/test/input-handler.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+import { stub } from 'sinon';
+import { CurrencyMaskConfig } from "../src/currency-mask.config";
+import { InputHandler } from "../src/input.handler";
+import { InputService } from './../src/input.service';
+import { MockHtmlInputElement } from "./mock-html-input-element";
+
+describe('Testing InputHandler', () => {
+
+    let options: CurrencyMaskConfig;
+    let inputElement: HTMLInputElement;
+    let inputHandler: InputHandler;
+    let inputService: InputService;
+
+    beforeEach(function () {
+        inputElement = new MockHtmlInputElement(0, 0) as unknown as HTMLInputElement;
+        options = {
+            prefix: '',
+            suffix: '',
+            thousands: '.',
+            decimal: ',',
+            allowNegative: false,
+            nullable: false,
+            align: 'right',
+            allowZero: true,
+            precision: undefined,
+        };
+
+        inputHandler = new InputHandler(inputElement, options);
+        inputService = inputHandler['inputService'];
+    });
+
+    describe('handleKeydown', () => {
+        it('should call clearValue if all text selected', () => {
+            options.prefix = '$$$';
+            options.suffix = 'SU';
+            inputService.rawValue = '$$$1,23SU';
+            inputElement.selectionStart = 0;
+            inputElement.selectionEnd = 9;
+            inputHandler.clearValue = stub();
+
+            const event = {
+                keyCode: 8,
+                preventDefault: stub(),
+            }
+            inputHandler.handleKeydown(event);
+            expect(event.preventDefault).to.be.calledOnce;
+            expect(inputHandler.clearValue).to.be.calledOnce;
+        });
+
+        it('should call clearValue if partial prefix through partial suffix selected', () => {
+            options.prefix = '$$$';
+            options.suffix = 'SU';
+            inputService.rawValue = '$$$1,23SU';
+            inputElement.selectionStart = 1;
+            inputElement.selectionEnd = 8;
+            inputHandler.clearValue = stub();
+
+            const event = {
+                keyCode: 46,
+                preventDefault: stub(),
+            }
+            inputHandler.handleKeydown(event);
+            expect(event.preventDefault).to.be.calledOnce;
+            expect(inputHandler.clearValue).to.be.calledOnce;
+        });
+
+        it('should call clearValue if all numbers selected', () => {
+            options.prefix = '$$$';
+            options.suffix = 'SU';
+            inputService.rawValue = '$$$1,23SU';
+            inputElement.selectionStart = 3;
+            inputElement.selectionEnd = 7;
+            inputHandler.clearValue = stub();
+
+            const event = {
+                keyCode: 63272,
+                preventDefault: stub(),
+            }
+            inputHandler.handleKeydown(event);
+            expect(event.preventDefault).to.be.calledOnce;
+            expect(inputHandler.clearValue).to.be.calledOnce;
+        });
+
+        it('should call removeNumber if subset of numbers selected', () => {
+            options.prefix = '$$$';
+            options.suffix = 'SU';
+            inputService.rawValue = '$$$1,23SU';
+            inputElement.selectionStart = 3;
+            inputElement.selectionEnd = 4;
+            inputService.removeNumber = stub();
+            inputHandler.setOnModelChange(stub());
+
+            const event = {
+                keyCode: 46,
+                preventDefault: stub(),
+            }
+            inputHandler.handleKeydown(event);
+            expect(event.preventDefault).to.be.calledOnce;
+            expect(inputService.removeNumber).to.be.calledWith(46);
+            expect(inputHandler['onModelChange']).to.be.called;
+        });
+
+        it('should call removeNumber if cursor inside number area', () => {
+            options.prefix = '$$$';
+            options.suffix = 'SU';
+            inputService.rawValue = '$$$1,23SU';
+            inputElement.selectionStart = 5;
+            inputElement.selectionEnd = 5;
+            inputService.removeNumber = stub();
+            inputHandler.setOnModelChange(stub());
+
+            const event = {
+                keyCode: 8,
+                preventDefault: stub(),
+            }
+            inputHandler.handleKeydown(event);
+            expect(event.preventDefault).to.be.calledOnce;
+            expect(inputService.removeNumber).to.be.calledWith(8);
+            expect(inputHandler['onModelChange']).to.be.called;
+        });
+    });
+});

--- a/test/mock-html-input-element.ts
+++ b/test/mock-html-input-element.ts
@@ -1,0 +1,19 @@
+export class MockHtmlInputElement {
+
+    public focused: boolean;
+    public value = '';
+
+    constructor(
+        public selectionStart: number,
+        public selectionEnd: number,
+    ) { }
+
+    public focus(): void {
+        this.focused = true;
+    }
+
+    public setSelectionRange(selectionStart: number, selectionEnd: number): void {
+        this.selectionStart = selectionStart;
+        this.selectionEnd = selectionEnd;
+    }
+}


### PR DESCRIPTION
The branch fixes a bunch of issues with deleting and backspacing in both
natural and financial mode:

* Currently, deleting the decimal in natural mode moves the decimal
portion into the whole number. Now, deleting the decimal move the whole
number into the decimal. See issue #85.
* Pressing backspace in the decimal portion of the number in natural
mode now shifts back to the previous decimal, allowing you to press
backspace multiple times and keep removing numbers.
* Currently, if you select a subset of the numbers and press delete or backspace, nothing happens. Now it will be deleted.
* Currently, if you select most numbers plus the suffix and press delete, the entire number is cleared. This is because the code is comparing selection length to total length without considering suffix length. This is also fixed.
* Currently, pressing backspace before a decimal or comma does nothing. Now it will delete the preceeding number.
* Currently, pressing backspace in the prefix either jumps to the end or to the second digit (depending on the version). Now it will jump to just after the prefix.
* Currently if you press delete before a comma or a decimal, the cursor jumps over it without deleting anything. Now, the cursor jumps over it AND deletes the next digit.
* Also fixes some random issues where the cursor can end up in a place
you don't expect it to.