### PR TITLE
Pull request to add dynamic variable to show or hide "-" operator

### DIFF
--- a/src/currency-mask.config.ts
+++ b/src/currency-mask.config.ts
@@ -3,6 +3,7 @@ import {InjectionToken} from "@angular/core";
 export interface CurrencyMaskConfig {
   align: string;
   allowNegative: boolean;
+  showNegativeOperator: boolean;
   allowZero: boolean;
   decimal: string;
   precision: number;

--- a/src/currency-mask.directive.ts
+++ b/src/currency-mask.directive.ts
@@ -37,6 +37,7 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
   public optionsTemplate: CurrencyMaskConfig = {
       align: "right",
       allowNegative: true,
+      showNegativeOperator: true,
       allowZero: true,
       decimal: ".",
       precision: 2,

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -83,7 +83,7 @@ export class InputService {
     }
 
     applyMask(isNumber: boolean, rawValue: string, disablePadAndTrim = false): string {
-        let {allowNegative, decimal, precision, prefix, suffix, thousands, min, max, inputMode} = this.options;
+        let {allowNegative, showNegativeOperator, decimal, precision, prefix, suffix, thousands, min, max, inputMode} = this.options;
 
         rawValue = isNumber ? new Number(rawValue).toFixed(precision) : rawValue;
         let onlyNumbers = rawValue.replace(this.ONLY_NUMBERS_REGEX, "");
@@ -139,7 +139,7 @@ export class InputService {
         }
 
         let isZero = newValue == 0;
-        let operator = (isNegative && allowNegative && !isZero) ? "-" : "";
+        let operator = (isNegative && allowNegative && showNegativeOperator && !isZero) ? "-" : "";
         return operator + prefix + newRawValue + suffix;
     }
 

--- a/test/currency-mask-config.spec.ts
+++ b/test/currency-mask-config.spec.ts
@@ -11,6 +11,7 @@ describe('Testing CurrencyMaskConfig', () => {
       thousands: '.',
       decimal: ',',
       allowNegative: false,
+      showNegativeOperator: false,
       nullable: false
     }];
 

--- a/test/input-handler.spec.ts
+++ b/test/input-handler.spec.ts
@@ -20,6 +20,7 @@ describe('Testing InputHandler', () => {
             thousands: '.',
             decimal: ',',
             allowNegative: false,
+            showNegativeOperator: false,
             nullable: false,
             align: 'right',
             allowZero: true,

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -16,6 +16,7 @@ describe('Testing InputService', () => {
       thousands: '.',
       decimal: ',',
       allowNegative: false,
+      showNegativeOperator: false,
       nullable: false,
       align: 'right',
       allowZero: true,


### PR DESCRIPTION
Added "showNegativeOperator" as a variable which will prepend the "-" sign only if this operator is set to true if not it will return with the prefix & suffix without the operator.

I am using this currency mask in my project, the only limitation is to hide the "-" operator since i am using prefix & suffix which are being used to represent the negative numbers
