### PR TITLE
fix: fix android chrome support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,17 @@ export class...
 Run `npm start` or `npm run demo` to start a development server on port 8000 with auto reload + tests.
 
 ### Testing
-Run `npm test` to run tests once or `npm run test:watch` to continually run tests.
+* Run `npm test` to run tests once
+* Run `npm run test:watch` to continually run tests in headless mode
+* Run `npm run test:watch-browser` to continually run tests in the Chrome browser
+
+When running in the Chrome browser, you can set code breakpoints to debug tests using these instructions:
+* From the main Karma browser page, click the `Debug` button to open the debug window
+* Press `ctrl + shift + i` to open Chrome developer tools
+* Press `ctrl + p` to search for a file to debug
+* Enter a file name like `input.handler.ts` and click the file
+* Within the file, click on a row number to set a breakpoint
+* Refresh the browser window to re-run tests and stop on the breakpoint
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:clean": "del-cli dist",
     "test": "nyc --reporter=html karma start --coverage --single-run && npm run build:dist && npm run build:clean",
     "test:watch": "karma start --auto-watch",
+    "test:watch-browser": "karma start --auto-watch --browsers Chrome",
     "commit": "git-cz",
     "compodoc": "compodoc -p tsconfig-compodoc.json -d docs --disableGraph --disableCoverage --disablePrivateOrInternalSupport",
     "gh-pages": "git checkout gh-pages && git merge master --no-edit --no-ff && npm run build:demo && npm run compodoc && git add . && git commit -m \"chore: build demo and docs\" && git push && git checkout master",

--- a/test/input-handler.spec.ts
+++ b/test/input-handler.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { stub } from 'sinon';
-import { CurrencyMaskConfig } from "../src/currency-mask.config";
+import { CurrencyMaskConfig, CurrencyMaskInputMode } from "../src/currency-mask.config";
 import { InputHandler } from "../src/input.handler";
 import { InputService } from './../src/input.service';
 import { MockHtmlInputElement } from "./mock-html-input-element";
@@ -12,7 +12,7 @@ describe('Testing InputHandler', () => {
     let inputHandler: InputHandler;
     let inputService: InputService;
 
-    beforeEach(function () {
+    beforeEach(() => {
         inputElement = new MockHtmlInputElement(0, 0) as unknown as HTMLInputElement;
         options = {
             prefix: '',
@@ -23,11 +23,93 @@ describe('Testing InputHandler', () => {
             nullable: false,
             align: 'right',
             allowZero: true,
-            precision: undefined,
+            precision: 0,
         };
 
         inputHandler = new InputHandler(inputElement, options);
         inputService = inputHandler['inputService'];
+
+        inputHandler.setOnModelChange(stub());
+    });
+
+    describe('handleInput', () => {
+        beforeEach(() => {
+          options.prefix = '$';
+
+          // Invoke async callbacks synchronously.
+          inputHandler['timer'] = (callback: () => void, delayMillis: number) => {
+            callback();
+          }
+        });
+
+        it('handles more than 1 character changes', () => {
+            inputService.rawValue = '$12.345';
+            inputElement.selectionStart = 5;
+            inputService.inputManager['_storedRawValue'] = '$123';
+
+            inputHandler.handleInput(null);
+            expect(inputService.rawValue).to.be.equal('$12.345');
+            expect(inputHandler['onModelChange']).to.be.calledWith(12345);
+        });
+
+        it('handles 1 character removed', () => {
+            inputService.rawValue = '$1.245';
+            inputElement.selectionStart = 4;
+            inputService.inputManager['_storedRawValue'] = '$12.345';
+
+            inputHandler.handleInput(null);
+            expect(inputService.rawValue).to.be.equal('$1.245');
+            expect(inputHandler['onModelChange']).to.be.calledWith(1245);
+        });
+
+        it('handles last character removed in natural mode', () => {
+            options.precision = 2;
+            options.inputMode = CurrencyMaskInputMode.NATURAL;
+            inputService.rawValue = '$123,4';
+            inputElement.selectionStart = 6;
+            inputService.inputManager['_storedRawValue'] = '$123,45';
+
+            inputHandler.handleInput(null);
+            expect(inputService.rawValue).to.be.equal('$123,40');
+            expect(inputElement.selectionStart).to.be.equal(6);
+            expect(inputHandler['onModelChange']).to.be.calledWith(123.40);
+        });
+
+        it('handles 1 character added', () => {
+            inputService.rawValue = '$123.945';
+            inputElement.selectionStart = 6;
+            inputService.inputManager['_storedRawValue'] = '$12.345';
+
+            inputHandler.handleInput(null);
+            expect(inputService.rawValue).to.be.equal('$123.945');
+            expect(inputHandler['onModelChange']).to.be.calledWith(123945);
+        });
+
+        it('handles 1 character added in natural mode after decimal', () => {
+            options.precision = 2;
+            options.inputMode = CurrencyMaskInputMode.NATURAL;
+            inputService.rawValue = '$123,945';
+            inputElement.selectionStart = 6;
+            inputService.inputManager['_storedRawValue'] = '$123,45';
+
+            inputHandler.handleInput(null);
+            expect(inputService.rawValue).to.be.equal('$123,95');
+            expect(inputElement.selectionStart).to.be.equal(6);
+            expect(inputHandler['onModelChange']).to.be.calledWith(123.95);
+        });
+
+        it('handles 1 character added in natural mode before decimal', () => {
+            options.precision = 2;
+            options.inputMode = CurrencyMaskInputMode.NATURAL;
+            inputService.rawValue = '$1293,45';
+            inputElement.selectionStart = 4;
+            inputService.inputManager['_storedRawValue'] = '$123,45';
+
+            inputHandler.handleInput(null);
+            expect(inputService.rawValue).to.be.equal('$1.293,45');
+            expect(inputElement.selectionStart).to.be.equal(5);
+            expect(inputHandler['onModelChange']).to.be.calledWith(1293.45);
+        });
     });
 
     describe('handleKeydown', () => {
@@ -89,7 +171,6 @@ describe('Testing InputHandler', () => {
             inputElement.selectionStart = 3;
             inputElement.selectionEnd = 4;
             inputService.removeNumber = stub();
-            inputHandler.setOnModelChange(stub());
 
             const event = {
                 keyCode: 46,
@@ -108,7 +189,6 @@ describe('Testing InputHandler', () => {
             inputElement.selectionStart = 5;
             inputElement.selectionEnd = 5;
             inputService.removeNumber = stub();
-            inputHandler.setOnModelChange(stub());
 
             const event = {
                 keyCode: 8,


### PR DESCRIPTION
This change fixes some issues in Android Chrome. Android Chrome doesn't send keypress event, so we rely on input events instead. The old input event handler code was basically duplicating code in the keypress handler, but it wasn't as robust, especially after we added support for natural mode. For example it assumed the cursor was always at the end of the input, so it isn't possible to add or delete a digit in the middle of the number. It doesn't allow you to add digits at all in natural mode.

The new code delegates to the existing keypress handler when adding digits, resulting in consistent functionality with desktop browsers. The algorithm is simple. Figure out what character was added, restore the old string, then call handleKeyPress with the new character.

I also tweaked the remove logic by setting the selection index before calling remove number, so it's now possible to remove a digit at any index.

In addition to adding unit tests, I tested this on an Android Simulator and my personal android device

Addresses issues #90 and #100.

cc: @nbfontana 
