### PR TITLE
fix: Allow backspacing of single whole numbers in Natural mode prior to the decimal

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -245,7 +245,7 @@ export class InputService {
                 if (inputMode === CurrencyMaskInputMode.NATURAL && isCursorInDecimals) {
                     shiftSelection = -1;
                     // when removing a single whole number, replace it with 0
-                    if (isCursorImmediatelyAfterDecimalPoint && this.value < 10) {
+                    if (isCursorImmediatelyAfterDecimalPoint && this.value < 10 && this.value > -10) {
                         insertChars += '0';
                     }
                 }

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -226,7 +226,9 @@ export class InputService {
         }
 
         let shiftSelection = 0;
-        let insertChars = '';   
+        let insertChars = '';
+        const isCursorInDecimals = decimalIndex < selectionEnd;
+        const isCursorImmediatelyAfterDecimalPoint = decimalIndex + 1 === selectionEnd;
         if (selectionEnd === selectionStart) {
             if (keyCode == 8) {
                 if (selectionStart <= prefix.length) {
@@ -240,8 +242,12 @@ export class InputService {
                 }
 
                 // In natural mode, jump backwards when in decimal portion of number.
-                if (inputMode === CurrencyMaskInputMode.NATURAL && decimalIndex < selectionEnd) {
+                if (inputMode === CurrencyMaskInputMode.NATURAL && isCursorInDecimals) {
                     shiftSelection = -1;
+                    // when removing a single whole number, replace it with 0
+                    if (isCursorImmediatelyAfterDecimalPoint && this.value < 10) {
+                        insertChars += '0';
+                    }
                 }
             } else if (keyCode == 46 || keyCode == 63272) {
                 if (selectionStart === suffixStart) {

--- a/test/input-service.spec.ts
+++ b/test/input-service.spec.ts
@@ -168,6 +168,21 @@ describe('Testing InputService', () => {
       expect(inputService.rawValue).to.be.equal('$$12,00SUF');
       expect(htmlInputElement.selectionStart).to.be.equal(4);
       expect(htmlInputElement.selectionEnd).to.be.equal(4);
+
+      inputService.removeNumber(8);
+      expect(inputService.rawValue).to.be.equal('$$1,00SUF');
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
+
+      inputService.removeNumber(8);
+      expect(inputService.rawValue).to.be.equal('$$0,00SUF');
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
+
+      inputService.removeNumber(8);
+      expect(inputService.rawValue).to.be.equal('$$0,00SUF');
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
     });
 
     it('should replace decimals with 0s when deleting in natural mode', () => {
@@ -187,6 +202,20 @@ describe('Testing InputService', () => {
       expect(inputService.rawValue).to.be.equal('$$1.234,00SUF');
       expect(htmlInputElement.selectionStart).to.be.equal(10);
       expect(htmlInputElement.selectionEnd).to.be.equal(10);
+    });
+
+    it('should replace single whole numbers with 0s when backspacing in natural mode', () => {
+      const htmlInputElement = new MockHtmlInputElement(4, 4);
+      options.prefix = '$$';
+      options.suffix = 'SUF';
+      options.inputMode = CurrencyMaskInputMode.NATURAL
+      inputService = new InputService(htmlInputElement, options);
+      inputService.rawValue = '$$1,00SUF';
+
+      inputService.removeNumber(8);
+      expect(inputService.rawValue).to.be.equal('$$0,00SUF');
+      expect(htmlInputElement.selectionStart).to.be.equal(3);
+      expect(htmlInputElement.selectionEnd).to.be.equal(3);
     });
 
     it('should delete if no precision in natural mode', () => {


### PR DESCRIPTION
This fixes an issue where in natural mode with a single digit whole number backspacing after the decimal removes the whole number and replaces it with 0 but the cursor is still after the decimal.