### PR TITLE
fix: export configuration token

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
 export * from './src/currency-mask.directive';
 export * from './src/currency-mask.module';
-export { CurrencyMaskConfig, CurrencyMaskInputMode } from './src/currency-mask.config';
+export { CurrencyMaskConfig, CurrencyMaskInputMode, CURRENCY_MASK_CONFIG } from './src/currency-mask.config';

--- a/test/currency-mask-config.spec.ts
+++ b/test/currency-mask-config.spec.ts
@@ -1,4 +1,5 @@
 import { InputService } from './../src/input.service';
+import { CURRENCY_MASK_CONFIG } from '..';
 import { expect } from "chai";
 
 describe('Testing CurrencyMaskConfig', () => {
@@ -29,5 +30,9 @@ describe('Testing CurrencyMaskConfig', () => {
     inputService.updateOptions(option);
     inputService.value = null;
     expect(0).to.equals(inputService.clearMask(""));
+  });
+
+  it('should export the injection token', () => {
+    expect(CURRENCY_MASK_CONFIG).to.not.be.undefined;
   });
 });


### PR DESCRIPTION
Allow usage of CURRENCY_MASK_CONFIG (e.g. when using a class to implement custom mask).

closes #116 