### PR TITLE
Update currency-mask.config.ts

### DIFF
--- a/src/currency-mask.config.ts
+++ b/src/currency-mask.config.ts
@@ -10,8 +10,8 @@ export interface CurrencyMaskConfig {
   suffix: string;
   thousands: string;
   nullable: boolean;
-  min?: number;
-  max?: number;
+  min?: number|null;
+  max?: number|null;
   inputMode? : CurrencyMaskInputMode;
 }
 


### PR DESCRIPTION
to fix
Types of property 'min' are incompatible.
    Type 'null' is not assignable to type 'number | undefined'