### PR TITLE
Improve changeToNegative in NATURAL mode

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -195,6 +195,14 @@ export class InputService {
         if (this.options.allowNegative /*&& this.rawValue != ""*/ && this.rawValue.charAt(0) != "-" /*&& this.value != 0*/) {
             // Apply the mask to ensure the min and max values are enforced.
             this.rawValue = this.applyMask(false, "-" + (this.rawValue ? this.rawValue : '0'));
+
+            if (this.options.inputMode === CurrencyMaskInputMode.NATURAL && this.value === 0) {
+                // If the value is 0, the raw value now looks like "$ -0", "$ -0.00", "-0 €", "-0.00 €" etc.
+                // In NATURAL mode we want to continue typing the number in front of the decimal point.
+                // So set the cursor just behind the first zero ('|' marks the new cursor position):
+                // "$ -0|", "$ -0|.00", "-0| €", "-0|.00 €"
+                this.updateFieldValue(this.rawValue.indexOf("0") + 1);
+            }
         }
     }
 


### PR DESCRIPTION
This change improves the typing of negative numbers in NATURAL mode when starting to type in an empty/zero-valued field. In NATURAL mode the user expects that typing [-] [1] [2] [3] leads to a field value of  e.g. "$ -123". With this change input handling is still not perfect in NATURAL mode, but it allows you to continue typing numbers after hitting [-] on an empty/zeroish input.

